### PR TITLE
feat: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  workflow_trigger:
+    branches: [ master ]
+
+jobs:
+  Deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2 
+      - name: Restart the systemd service
+        env:
+            PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+            HOSTNAME: ${{secrets.SSH_HOST}}
+            USER_NAME: ${{secrets.USER_NAME}}
+      
+        run: |
+          echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
+          ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOSTNAME} '
+
+              sudo systemctl restart color-rp.service
+              '


### PR DESCRIPTION
Adds a GitHub Workflow for deploying the backend.

In order for this workflow to work, the following things need to be added to the repository secrets (under settings):
- [ ] SSH_PRIVATE_KEY - can be found [here][1]
- [ ] SSH_HOST - `ec2-18-197-200-123.eu-central-1.compute.amazonaws.com`
- [ ] USER_NAME - `ubuntu`

[1]: https://eu-central-1.console.aws.amazon.com/secretsmanager/secret?name=color-rp%2Fcolor-rp-ec2-private-key&region=eu-central-1